### PR TITLE
bot commands: CR of CRUD done + lil !acro help command

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -10,23 +10,27 @@ const mongoDBClient = new MongoClient(uri, {
   useUnifiedTopology: true,
 });
 
-export async function getDefinition() {
+export interface Definition {
+  item: string;
+  definition: string;
+}
+
+export async function getDefinition(item: string): Promise<Definition | undefined> {
   try {
     await mongoDBClient.connect();
 
     const database = mongoDBClient.db('acrobot');
     const definitions = database.collection('definitions');
 
-    return definitions.findOne({
-      // should not be hardcoded
-      item: 'LP',
-    });
+    // TODO: we should decide what to do with acronyms that have >1 definition
+    // For SPOCS, gonna keep it simple and just encourage people to add both definitions to the item
+    return definitions.findOne({ item });
   } catch (error) {
     console.log(error);
   }
 }
 
-export async function addDefinition() {
+export async function upsertDefinition() {
   try {
     await mongoDBClient.connect();
 
@@ -38,3 +42,4 @@ export async function addDefinition() {
     console.log(error);
   }
 }
+

--- a/src/db.ts
+++ b/src/db.ts
@@ -28,15 +28,15 @@ export async function getDefinition(item: string): Promise<Definition | undefine
   }
 }
 
-export async function upsertDefinition() {
+export async function upsertDefinition(item: string, definition: string) {
   try {
     await mongoDBClient.connect();
 
     const database = mongoDBClient.db('acrobot');
     const definitions = database.collection('definitions');
-
-    // add new definition to mongodb
+    await definitions.updateOne({ item }, { $set: { item, definition }}, { upsert: true });
   } catch (error) {
+    // TODO: Actually handle errors upstream
     console.log(error);
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,18 +2,16 @@ import { MongoClient } from 'mongodb';
 import dotenv from 'dotenv';
 
 dotenv.config();
-
-const uri = `mongodb+srv://admin:${process.env.MONGO_DB_PASSWORD}@cluster0.qq6rw.mongodb.net?retryWrites=true&w=majority`;
-
-const mongoDBClient = new MongoClient(uri, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
-
 export interface Definition {
   item: string;
   definition: string;
 }
+
+const uri = `mongodb+srv://admin:${process.env.MONGO_DB_PASSWORD}@cluster0.qq6rw.mongodb.net?retryWrites=true&w=majority`;
+const mongoDBClient = new MongoClient(uri, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
 
 export async function getDefinition(item: string): Promise<Definition | undefined> {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,48 @@
 import Discord, { Message } from 'discord.js';
+
 import { getDefinition } from './db';
 
 const discordClient = new Discord.Client();
 
 const prefix = '!';
 
+const COMMANDS = ['acro', 'def', 'add', 'edit', 'del'];
+
 discordClient.on('message', async function (message: Message) {
-  if (message.author.bot) return;
-  if (!message.content.startsWith(prefix)) return;
+  const { author, content, channel } = message;
+
+  if (author.bot) return;
+  if (!content.startsWith(prefix)) return;
 
   // strip da prefix
-  const item = message.content.substring(1);
-  
-  const result = await getDefinition(item);
-  if (!result) {
-    message.channel.send(`Boop! Don't have that in my dictionary yet, why don't you add it using !add <term> <definition>`)
-  } else {
-    const { item: term, definition } = result;
-    message.channel.send(`${term}: ${definition}`);
+  const instructions = content.substring(1);
+
+  // interpret message content
+  const [command, ...args] = instructions.split(' ');
+
+  switch (command) {
+    // usage
+    case 'acro':
+      const commands = COMMANDS.join(', ');
+      channel.send(`The commands I understand are ${commands}.`)
+      break;
+    // get definition
+    case 'def':
+      if (args.length !== 1) channel.send(`Boop! I don't know how to look that up. Try !def <term>`);
+      const [ item ] = args;
+      const result = await getDefinition(item);
+      if (!result) {
+        channel.send(`Boop! Don't have that in my dictionary yet, why don't you add it using !add <term> <definition>`)
+      } else {
+        const { item: term, definition } = result;
+        channel.send(`${term}: ${definition}`);
+      }
+      break;
+    case 'add':
+    case 'edit':
+    case 'del':
+    default:
+      channel.send(`Boop! I don't understand this command. Try !acro to see what I can do.`)
   }
   return;
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,17 @@ discordClient.on('message', async function (message: Message) {
   if (message.author.bot) return;
   if (!message.content.startsWith(prefix)) return;
 
-  const result = await getDefinition();
-
-  return message.channel.send(`${result.item}: ${result.definition}`);
+  // strip da prefix
+  const item = message.content.substring(1);
+  
+  const result = await getDefinition(item);
+  if (!result) {
+    message.channel.send(`Boop! Don't have that in my dictionary yet, why don't you add it using !add <term> <definition>`)
+  } else {
+    const { item: term, definition } = result;
+    message.channel.send(`${term}: ${definition}`);
+  }
+  return;
 });
 
 discordClient.login(process.env.DISCORD_BOT_TOKEN);


### PR DESCRIPTION
the acrobot - she:

* !acro - help command that lists all of the commands available
* !def <term> - looks up persisted definition associated with term, shows err message if not found
* !add <term> <definition> - upserts definition for term

some notables:
* at some point lol we should handle any mongo errors/runtime errors in a naice way
* idk wtf happened with my brain re: variable naming but a lot of the like `item`/`term` variable naming is a little stupid, so should refactor that a bit better
* big ol' switch-case statement; there's probably some refactoring we could do there but i wanted to get a lay of the land for now and didn't want too many abstractions