### PR TITLE
only send unrecognized command message in DM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ discordClient.on('message', async function (message: Message) {
 
   if (!content.startsWith(botPrefix)) return;
 
+  const isBotCommand = Object.values(COMMANDS).some(command => content.startsWith(`${botPrefix}${command}`));
+  if (channel.type !== 'dm' && !isBotCommand) return;
+
   // strip da prefix
   const instructions = content.substring(1);
 


### PR DESCRIPTION
This PR updates the bot to only post the unrecognized command message if the command is sent via DM. This is to prevent an issue where sending a command intended for a different bot in a channel triggers the message.

### Example
<img width="569" alt="Screen Shot 2021-05-16 at 10 34 33 PM" src="https://user-images.githubusercontent.com/1393139/118432192-96241580-b69d-11eb-9289-2a8c353ff50b.png">